### PR TITLE
Fix: CommonSetup enqueueWork usage

### DIFF
--- a/src/main/java/net/regions_unexplored/RegionsUnexploredMod.java
+++ b/src/main/java/net/regions_unexplored/RegionsUnexploredMod.java
@@ -116,11 +116,13 @@ public class RegionsUnexploredMod {
 
     //set up non-client side features
     private void commonSetup(final FMLCommonSetupEvent event) {
-        BiomeRegistry.setupTerrablender();
-        PottedPlants.setup();
-        CompostableBlocks.setup();
-        FlammableBlocks.setup();
-        BlockToolCompat.setup();
+        event.enqueueWork(() -> {
+            BiomeRegistry.setupTerrablender();
+            PottedPlants.setup();
+            CompostableBlocks.setup();
+            FlammableBlocks.setup();
+            BlockToolCompat.setup();
+        });
     }
 
     private static void registerFoliagePlacers(){


### PR DESCRIPTION
Fixed a wrongly handled commonSetup with the correct usage of event.enqueueWork as defined [here](https://docs.neoforged.net/docs/concepts/events/#the-mod-lifecycle).