### PR TITLE
Delete redstone_ores.json

### DIFF
--- a/src/generated/resources/data/minecraft/tags/item/redstone_ores.json
+++ b/src/generated/resources/data/minecraft/tags/item/redstone_ores.json
@@ -1,5 +1,0 @@
-{
-  "values": [
-    "regions_unexplored:raw_redstone_block"
-  ]
-}


### PR DESCRIPTION
Removes Redstone Ore Tag from the Raw Redstone Block as it leads to duplication recipes when with other mods.